### PR TITLE
Add folder detection for osu! linux (osu-winello)

### DIFF
--- a/src/main/router/dir-router.ts
+++ b/src/main/router/dir-router.ts
@@ -1,9 +1,7 @@
-import { Router } from '../lib/route-pass/Router';
-import { none, some } from '../lib/rust-like-utils-backend/Optional';
-import { dialog } from 'electron';
+import { Router } from "../lib/route-pass/Router";
+import { none, some } from "../lib/rust-like-utils-backend/Optional";
+import { dialog } from "electron";
 import path from "path";
-
-
 
 let waitList: ((dir: string) => void)[] = [];
 
@@ -21,11 +19,18 @@ Router.respond("dir::select", () => {
 });
 
 Router.respond("dir::autoGetOsuSongsDir", () => {
-  if (process.env.LOCALAPPDATA === undefined) {
-    return none();
+  if (process.platform === "win32") {
+    if (process.env.LOCALAPPDATA === undefined) {
+      return none();
+    }
+    return some(path.join(process.env.LOCALAPPDATA, "osu!", "Songs"));
+  } else if (process.platform === "linux") {
+    if (process.env.XDG_DATA_HOME === undefined) {
+      return none();
+    }
+    return some(path.join(process.env.XDG_DATA_HOME, "osu-wine", "osu!", "Songs"));
   }
-
-  return some(path.join(process.env.LOCALAPPDATA, "osu!", "Songs"));
+  return none();
 });
 
 Router.respond("dir::submit", (_evt, dir) => {
@@ -36,10 +41,8 @@ Router.respond("dir::submit", (_evt, dir) => {
   waitList = [];
 });
 
-
-
 export function dirSubmit(): Promise<string> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     waitList.push(resolve);
   });
 }


### PR DESCRIPTION
Adds Linux support to the folder auto-detect. 
This assumes the install path of osu-winello, which is the most common way to install osu! on Linux.