### PR TITLE
fix: use pathToFileURL instead of regular URLs for cross-platform support

### DIFF
--- a/src/main/router/resource-router.ts
+++ b/src/main/router/resource-router.ts
@@ -7,8 +7,8 @@ import { fail, ok } from "../lib/rust-like-utils-backend/Result";
 import { Storage } from "../lib/storage/Storage";
 import { pathToFileURL } from "url";
 
-Router.respond("resource::getPath", (_evt, id) => {
-  if (id === undefined) {
+Router.respond("resource::getPath", (_evt, path) => {
+  if (path === undefined) {
     return fail("Can not find resource for 'undefined'.");
   }
 
@@ -19,7 +19,7 @@ Router.respond("resource::getPath", (_evt, id) => {
   }
 
   // todo User may have spaces in osuDir if they are not using default path. Ensure that the whole path is valid URL
-  return ok(pathToFileURL(id).href);
+  return ok(pathToFileURL(path).href);
 });
 
 Router.respond("resource::getMediaSessionImage", async (_evt, bgPath) => {

--- a/src/main/router/resource-router.ts
+++ b/src/main/router/resource-router.ts
@@ -5,6 +5,7 @@ import { Router } from "../lib/route-pass/Router";
 import { none, some } from "../lib/rust-like-utils-backend/Optional";
 import { fail, ok } from "../lib/rust-like-utils-backend/Result";
 import { Storage } from "../lib/storage/Storage";
+import { pathToFileURL } from "url";
 
 Router.respond("resource::getPath", (_evt, id) => {
   if (id === undefined) {
@@ -18,7 +19,7 @@ Router.respond("resource::getPath", (_evt, id) => {
   }
 
   // todo User may have spaces in osuDir if they are not using default path. Ensure that the whole path is valid URL
-  return ok(encodeFile(id));
+  return ok(pathToFileURL(id).href);
 });
 
 Router.respond("resource::getMediaSessionImage", async (_evt, bgPath) => {
@@ -36,13 +37,6 @@ Router.respond("resource::getMediaSessionImage", async (_evt, bgPath) => {
 
   return some(`data:${mimeType};base64,${buffer.toString("base64")}`);
 });
-
-function encodeFile(uri: string): string {
-  return uri
-    .split(/[\/\\]/)
-    .map((s, i) => i !== 0 ? encodeURIComponent(s): s)
-    .join("/");
-}
 
 Router.respond("resource::get", (_evt, id, table) => {
   return Storage.getTable(table).get(id);

--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -9,7 +9,7 @@ type ZeroToOne = number;
 
 const player = new Audio();
 
-const [media, setMedia] = createSignal<URL>();
+const [media, setMedia] = createSignal<string>();
 
 const [song, setSong] = createStore<Song>(createDefaultSong());
 export { song };
@@ -70,7 +70,7 @@ export { bpm };
 const [isPlaying, setIsPlaying] = createSignal<boolean>(false);
 export { isPlaying };
 
-async function getCurrent(): Promise<{ song: Song; media: URL } | undefined> {
+async function getCurrent(): Promise<{ song: Song; media: string } | undefined> {
   const song = await window.api.request("queue::current");
 
   if (song.isNone) {
@@ -82,11 +82,9 @@ async function getCurrent(): Promise<{ song: Song; media: URL } | undefined> {
   if (resource.isError) {
     return;
   }
-  const media = new URL(resource.value);
-
   return {
     song: song.value,
-    media
+    media: resource.value
   };
 }
 
@@ -105,8 +103,8 @@ export async function play(): Promise<void> {
 
   const m = media();
 
-  if (m !== undefined && player.src !== m.href) {
-    player.src = m.href;
+  if (m !== undefined && player.src !== m) {
+    player.src = m;
   }
 
   player.volume = calculateVolume();
@@ -139,7 +137,7 @@ export async function next() {
     return;
   }
 
-  player.src = current.media.href;
+  player.src = current.media;
   setMedia(current.media);
 
   if (isPlaying() === true) {
@@ -221,7 +219,7 @@ export async function previous() {
     return;
   }
 
-  player.src = current.media.href;
+  player.src = current.media;
   setMedia(current.media);
 
   if (isPlaying() === true) {
@@ -316,7 +314,7 @@ window.api.listen("queue::songChanged", async (s) => {
   if (resource.isError) {
     return;
   }
-  setMedia(new URL(`file://${decodeURIComponent(resource.value)}`));
+  setMedia(resource.value);
   setSong(s);
   await play();
 });

--- a/src/renderer/src/lib/tungsten/resource.ts
+++ b/src/renderer/src/lib/tungsten/resource.ts
@@ -1,6 +1,4 @@
-import { ResourceID } from '../../../../@types';
-
-
+import { ResourceID } from "../../../../@types";
 
 export async function getResourcePath(id: ResourceID | undefined): Promise<string> {
   const result = await window.api.request("resource::getPath", id);
@@ -9,10 +7,8 @@ export async function getResourcePath(id: ResourceID | undefined): Promise<strin
     return "";
   }
 
-  return new URL(result.value).href;
+  return result.value;
 }
-
-
 
 const seen = new Map<string, boolean>();
 
@@ -25,7 +21,7 @@ export function availableResource(resource: string, fallback: string): Promise<s
 
   const img = document.createElement("img");
 
-  const p = new Promise<string>(resolve => {
+  const p = new Promise<string>((resolve) => {
     img.addEventListener("load", () => {
       seen.set(resource, true);
       resolve(resource);


### PR DESCRIPTION
https://nodejs.org/api/url.html#urlpathtofileurlpath-options

Least amount of changes to get bg images working on every platform.

I'm honestly not entirely sure what the point of `resource::getPath` is when we always seem to pass an absolute path to it anyway. But I guess now the point is to run `pathToFileURL` on it which is only available in Node and not in the browser.

I feel like we could just store these bg and media file URLs on the Song object instead, maybe even in place of the regular paths if we only use them as URLs anyway (I'm not entirely sure if this is the case). Seems a bit useless to have a round-trip for every song element just to convert its paths to file:// URLs (if that's all that's happening, maybe I'm missing something).

Doing this for Linux support for myself. Tested on macOS and Windows by @Tnixc, but you do have to clear your local app data for it if you still had it from before the db branch was merged.