### PR TITLE
New implementation of handling subdirectories

### DIFF
--- a/src/main/lib/osu-file-parser/OsuParser.ts
+++ b/src/main/lib/osu-file-parser/OsuParser.ts
@@ -6,6 +6,7 @@ import { access } from "../fs-promises";
 import { fail, ok } from "../rust-like-utils-backend/Result";
 import { assertNever } from "../tungsten/assertNever";
 import { OsuFile } from "./OsuFile";
+import path from "path/posix";
 
 const bgFileNameRegex = /.*"(?<!Video.*)(.*)".*/;
 const beatmapSetIDRegex = /([0-9]+) .*/;
@@ -118,10 +119,18 @@ export class OsuParser {
   ): DirParseResult {
     let dbBuffer;
 
-    if (databasePath.includes("osu!")) {
-      // Handles any subdirectory of the 'osu!' folder when choosing a directory
-      databasePath = databasePath.substring(0, databasePath.lastIndexOf("osu!") + 4);
+    // Handles any subdirectory of the 'osu!' folder when choosing a directory
+    let currentDir = databasePath;
+    currentDir = databasePath.replaceAll("\\", "/");
+
+    while (currentDir !== path.dirname(currentDir)) {
+      if (fs.existsSync(path.join(currentDir, "osu!.db"))) {
+        databasePath = currentDir;
+        break;
+      }
+      currentDir = path.dirname(currentDir);
     }
+
     let songsFolderPath = databasePath + "/Songs";
 
     try {

--- a/src/main/lib/osu-file-parser/OsuParser.ts
+++ b/src/main/lib/osu-file-parser/OsuParser.ts
@@ -118,9 +118,13 @@ export class OsuParser {
     update?: (i: number, total: number, file: string) => any
   ): DirParseResult {
     let dbBuffer;
+    // NOTE: databasePath is not double slashed
+    // on windows this will cause uninteded behavior with 'path/posix'
+    // due to the path seperators attempting to escape the string
 
     // Handles any subdirectory of the 'osu!' folder when choosing a directory
     let currentDir = databasePath;
+    // Solution to the issue mentioned in the note above
     currentDir = databasePath.replaceAll("\\", "/");
 
     while (currentDir !== path.dirname(currentDir)) {


### PR DESCRIPTION
New implementation traverses the directories until it finds one with `osu!.db` and uses that folder. It checks the initial directory as well so if  `osu!.db` isn't found it'll fail, just as it did before. The old implementation had issues just as was mentioned in #41, this will fix the major ones at least. If this keep causing issues, then either revert it back to *not* accounting for sub-directories, or ask the user to locate the `osu!.db` file itself instead of the folder it's stored in.