### PR TITLE
Fix discord rich presence length

### DIFF
--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -41,7 +41,7 @@ export type RequestAPI = {
   "dir::autoGetOsuDir": () => Optional<string>;
   "dir::submit": (dir: string) => void;
 
-  "discord::play": (song: Song, duration?: number) => void;
+  "discord::play": (song: Song, duration: number, songLength: number) => void;
   "discord::pause": (song: Song) => void;
 
   "error::dismissed": () => void;

--- a/src/main/router/discord-router.ts
+++ b/src/main/router/discord-router.ts
@@ -14,9 +14,9 @@ const defaultPresence: SetActivity = {
   buttons: [{ label: "Check out osu!radio", url: "https://github.com/Team-BTMC/osu-radio" }]
 };
 
-Router.respond("discord::play", async (_evt, song, duration) => {
+Router.respond("discord::play", async (_evt, song, duration, songLength) => {
   const startTimestamp = new Date(new Date().getTime() - (duration ? duration * 1000 : 0));
-  const endTimestamp = startTimestamp.getTime() + song.duration * 1000;
+  const endTimestamp = startTimestamp.getTime() + songLength * 1000;
 
   const response = await fetch(
     `https://assets.ppy.sh/beatmaps/${song.beatmapSetID}/covers/list@2x.jpg`,

--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -110,7 +110,7 @@ export async function play(): Promise<void> {
 
   setTimeout(async () => {
     await window.api.request("discord::play", current.song, player.currentTime, player.duration);
-  }, 1000);
+  }, 400);
 
   if (m !== undefined && player.src !== m) {
     player.src = m;

--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -108,9 +108,9 @@ export async function play(): Promise<void> {
 
   const m = media();
 
-  setTimeout(async () => {
+  player.onloadedmetadata = async () => {
     await window.api.request("discord::play", current.song, player.currentTime, player.duration);
-  }, 400);
+  };
 
   if (m !== undefined && player.src !== m) {
     player.src = m;
@@ -247,8 +247,14 @@ export async function previous() {
 }
 
 export async function togglePlay(force?: boolean): Promise<void> {
+  const current = await getCurrent();
+  if (!current) {
+    return;
+  }
+
   if (force !== undefined) {
     if (force === true) {
+      await window.api.request("discord::play", current.song, timestamp(), duration());
       await play();
       return;
     }
@@ -261,7 +267,7 @@ export async function togglePlay(force?: boolean): Promise<void> {
     await pause();
     return;
   }
-
+  await window.api.request("discord::play", current.song, timestamp(), duration());
   await play();
 }
 
@@ -272,14 +278,14 @@ export async function seek(range: ZeroToOne): Promise<void> {
 
   player.currentTime = range * player.duration;
 
-  const song = await getCurrent();
-  if (!song) {
+  const current = await getCurrent();
+  if (!current) {
     return;
   }
 
-  setTimeout(async () => {
-    await window.api.request("discord::play", song.song, player.currentTime, player.duration);
-  }, 400);
+  player.onloadedmetadata = async () => {
+    await window.api.request("discord::play", current.song, player.currentTime, player.duration);
+  };
 
   setDuration(player.duration);
   setTimestamp(player.currentTime);

--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -108,9 +108,9 @@ export async function play(): Promise<void> {
 
   const m = media();
 
-  player.onloadedmetadata = async () => {
+  player.addEventListener("loadedmetadata", async () => {
     await window.api.request("discord::play", current.song, player.currentTime, player.duration);
-  };
+  });
 
   if (m !== undefined && player.src !== m) {
     player.src = m;
@@ -283,9 +283,9 @@ export async function seek(range: ZeroToOne): Promise<void> {
     return;
   }
 
-  player.onloadedmetadata = async () => {
+  player.addEventListener("loadedmetadata", async () => {
     await window.api.request("discord::play", current.song, player.currentTime, player.duration);
-  };
+  });
 
   setDuration(player.duration);
   setTimestamp(player.currentTime);

--- a/src/renderer/src/lib/Music.ts
+++ b/src/renderer/src/lib/Music.ts
@@ -108,7 +108,9 @@ export async function play(): Promise<void> {
 
   const m = media();
 
-  await window.api.request("discord::play", current.song, player.currentTime);
+  setTimeout(async () => {
+    await window.api.request("discord::play", current.song, player.currentTime, player.duration);
+  }, 1000);
 
   if (m !== undefined && player.src !== m) {
     player.src = m;
@@ -275,7 +277,9 @@ export async function seek(range: ZeroToOne): Promise<void> {
     return;
   }
 
-  await window.api.request("discord::play", song.song, player.currentTime);
+  setTimeout(async () => {
+    await window.api.request("discord::play", song.song, player.currentTime, player.duration);
+  }, 400);
 
   setDuration(player.duration);
   setTimestamp(player.currentTime);
@@ -337,7 +341,6 @@ window.api.listen("queue::songChanged", async (s) => {
   }
   setMedia(resource.value);
   setSong(s);
-  await window.api.request("discord::play", s);
   await play();
 });
 


### PR DESCRIPTION
Right now, the rich presence would pull the length of the song from the value retrieved in osu!.db, however that length is the *drain time* and not the actual length of the mp3, so most of the time there was discrepancies. This gets around that by directly passing the duration from the player, however it's a little bit sketch because I had to put it in a setTimeout because player.duration takes some amount of time to load the data.