### PR TITLE
Remove titlebar and add drag region to navbar

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import { resolve } from "path";
+import lucidePreprocess from "vite-plugin-lucide-preprocess";
 import solid from "vite-plugin-solid";
 
 export default defineConfig({
@@ -15,6 +16,6 @@ export default defineConfig({
         "@renderer": resolve("src/renderer/src"),
       },
     },
-    plugins: [solid()],
+    plugins: [solid(), lucidePreprocess()],
   },
 });

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
         "@renderer": resolve("src/renderer/src"),
       },
     },
-    plugins: [solid(), lucidePreprocess()],
+    plugins: [lucidePreprocess(), solid()],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "solid-js": "^1.7.6",
         "typescript": "~5.5.0",
         "vite": "^5.4.8",
+        "vite-plugin-lucide-preprocess": "^1.1.1",
         "vite-plugin-solid": "^2.7.0"
       }
     },
@@ -9029,6 +9030,16 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-lucide-preprocess": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-lucide-preprocess/-/vite-plugin-lucide-preprocess-1.1.1.tgz",
+      "integrity": "sha512-VHmnK/4xAv/mntTSLA8ROQaWMxzMaZfmbOpC2JKmZt8aGnPiXNPbGPztCPkQslJOwoycwkhwKCjBjj2Y4JhUcg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^5"
       }
     },
     "node_modules/vite-plugin-solid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "fastest-levenshtein": "^1.0.16",
         "get-audio-duration": "^4.0.1",
         "graceful-fs": "^4.2.11",
+        "lucide-solid": "^0.452.0",
         "node-addon-api": "^8.2.1",
         "remixicon": "^4.3.0",
         "sharp": "^0.33.5",
@@ -6775,6 +6776,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-solid": {
+      "version": "0.452.0",
+      "resolved": "https://registry.npmjs.org/lucide-solid/-/lucide-solid-0.452.0.tgz",
+      "integrity": "sha512-7oYiRKSf4yDT3K0CIwKNlT13usUOAoTKxveiMjTKx3EV1ln/rgTdt6UtlgRY0n0eR8HujGefi0hE0Iy06OjOsA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "solid-js": "^1.4.7"
       }
     },
     "node_modules/magic-bytes.js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fastest-levenshtein": "^1.0.16",
     "get-audio-duration": "^4.0.1",
     "graceful-fs": "^4.2.11",
+    "lucide-solid": "^0.452.0",
     "node-addon-api": "^8.2.1",
     "remixicon": "^4.3.0",
     "sharp": "^0.33.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "solid-js": "^1.7.6",
     "typescript": "~5.5.0",
     "vite": "^5.4.8",
+    "vite-plugin-lucide-preprocess": "^1.1.1",
     "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/src/ListenAPI.d.ts
+++ b/src/ListenAPI.d.ts
@@ -14,5 +14,7 @@ export type ListenAPI = {
 
   "songView::reset": () => void;
 
+  "window::maximizeChange": (maximized: boolean) => void;
+
   notify: (notice: NoticeType) => void;
 };

--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -52,6 +52,10 @@ export type RequestAPI = {
   "settings::write": <K extends keyof Settings>(key: K, value: any) => void;
   "settings::get": <K extends keyof Settings>(key: K) => Optional<any>;
   "settings::getos": () => NodeJS.Platform;
+  "settings::close": () => void;
+  "settings::minimize": () => void;
+  "settings::maximize": () => void;
+  "settings::maximized": () => boolean;
 
   "query::songsPool::init": (payload: SongsQueryPayload) => InfiniteScrollerInitResponse;
   "query::songsPool": (

--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -51,6 +51,7 @@ export type RequestAPI = {
 
   "settings::write": <K extends keyof Settings>(key: K, value: any) => void;
   "settings::get": <K extends keyof Settings>(key: K) => Optional<any>;
+  "settings::getos": () => NodeJS.Platform;
 
   "query::songsPool::init": (payload: SongsQueryPayload) => InfiniteScrollerInitResponse;
   "query::songsPool": (

--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -57,7 +57,7 @@ export type RequestAPI = {
   "window::close": () => void;
   "window::minimize": () => void;
   "window::maximize": () => void;
-  "window::maximized": () => boolean;
+  "window::isMaximized": () => boolean;
 
   "query::songsPool::init": (payload: SongsQueryPayload) => InfiniteScrollerInitResponse;
   "query::songsPool": (

--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -52,10 +52,11 @@ export type RequestAPI = {
   "settings::write": <K extends keyof Settings>(key: K, value: any) => void;
   "settings::get": <K extends keyof Settings>(key: K) => Optional<any>;
   "settings::getos": () => NodeJS.Platform;
-  "settings::close": () => void;
-  "settings::minimize": () => void;
-  "settings::maximize": () => void;
-  "settings::maximized": () => boolean;
+
+  "window::close": () => void;
+  "window::minimize": () => void;
+  "window::maximize": () => void;
+  "window::maximized": () => boolean;
 
   "query::songsPool::init": (payload: SongsQueryPayload) => InfiniteScrollerInitResponse;
   "query::songsPool": (

--- a/src/RequestAPI.d.ts
+++ b/src/RequestAPI.d.ts
@@ -51,7 +51,8 @@ export type RequestAPI = {
 
   "settings::write": <K extends keyof Settings>(key: K, value: any) => void;
   "settings::get": <K extends keyof Settings>(key: K) => Optional<any>;
-  "settings::getos": () => NodeJS.Platform;
+
+  "os::platform": () => NodeJS.Platform;
 
   "window::close": () => void;
   "window::minimize": () => void;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,23 @@ async function createWindow() {
       sandbox: false,
       webSecurity: false,
     },
+    /* To be uncommented whenever the title bar is removed and
+    native buttons are added
+
+    titleBarOverlay: {
+      color: "#00000000", // transparent bg for the buttons
+      symbolColor: "#FFFFFF", // the icons are white
+      height: 30,
+    },
+    */
+  });
+
+  window.on("maximize", () => {
+    Router.dispatch(window, "window::maximizeChange", true);
+  });
+
+  window.on("unmaximize", () => {
+    Router.dispatch(window, "window::maximizeChange", false);
   });
 
   if (wasMaximized()) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,11 @@ async function createWindow() {
     height,
     show: false,
     autoHideMenuBar: true,
+    titleBarStyle: "hidden",
+    trafficLightPosition: {
+      x: 20,
+      y: 20,
+    },
     ...(process.platform === "linux" ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, "../preload/index.mjs"),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,14 @@ export let mainWindow: BrowserWindow;
 export async function main(window: BrowserWindow) {
   mainWindow = window;
 
+  mainWindow.on("maximize", () => {
+    mainWindow.webContents.send("maximize-change", true);
+  });
+
+  mainWindow.on("unmaximize", () => {
+    mainWindow.webContents.send("maximize-change", false);
+  });
+
   const settings = Storage.getTable("settings");
 
   // Deleting osuSongsDir will force initial beatmap import

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,14 +14,6 @@ export let mainWindow: BrowserWindow;
 export async function main(window: BrowserWindow) {
   mainWindow = window;
 
-  mainWindow.on("maximize", () => {
-    mainWindow.webContents.send("maximize-change", true);
-  });
-
-  mainWindow.on("unmaximize", () => {
-    mainWindow.webContents.send("maximize-change", false);
-  });
-
   const settings = Storage.getTable("settings");
 
   // Deleting osuSongsDir will force initial beatmap import

--- a/src/main/router/import.ts
+++ b/src/main/router/import.ts
@@ -10,3 +10,4 @@ import "./queue-router";
 import "./resource-router";
 import "./settings-router";
 import "./songs-pool-router";
+import "./window-router";

--- a/src/main/router/settings-router.ts
+++ b/src/main/router/settings-router.ts
@@ -1,5 +1,6 @@
 import { Router } from "../lib/route-pass/Router";
 import { Storage } from "../lib/storage/Storage";
+import os from "os";
 
 Router.respond("settings::get", (_evt, key) => {
   return Storage.getTable("settings").get(key);
@@ -7,4 +8,8 @@ Router.respond("settings::get", (_evt, key) => {
 
 Router.respond("settings::write", (_evt, key, value) => {
   Storage.getTable("settings").write(key, value);
+});
+
+Router.respond("settings::getos", (_evt) => {
+  return os.platform();
 });

--- a/src/main/router/settings-router.ts
+++ b/src/main/router/settings-router.ts
@@ -10,6 +10,6 @@ Router.respond("settings::write", (_evt, key, value) => {
   Storage.getTable("settings").write(key, value);
 });
 
-Router.respond("settings::getos", (_evt) => {
+Router.respond("os::platform", (_evt) => {
   return os.platform();
 });

--- a/src/main/router/settings-router.ts
+++ b/src/main/router/settings-router.ts
@@ -1,5 +1,6 @@
 import { Router } from "../lib/route-pass/Router";
 import { Storage } from "../lib/storage/Storage";
+import { mainWindow } from "../main";
 import os from "os";
 
 Router.respond("settings::get", (_evt, key) => {
@@ -12,4 +13,24 @@ Router.respond("settings::write", (_evt, key, value) => {
 
 Router.respond("settings::getos", (_evt) => {
   return os.platform();
+});
+
+Router.respond("settings::maximize", (_evt) => {
+  if (mainWindow.isMaximized()) {
+    mainWindow.unmaximize();
+    return;
+  }
+  mainWindow.maximize();
+});
+
+Router.respond("settings::maximized", (_evt) => {
+  return mainWindow.isMaximized();
+});
+
+Router.respond("settings::minimize", (_evt) => {
+  mainWindow.minimize();
+});
+
+Router.respond("settings::close", (_evt) => {
+  mainWindow.close();
 });

--- a/src/main/router/settings-router.ts
+++ b/src/main/router/settings-router.ts
@@ -1,6 +1,5 @@
 import { Router } from "../lib/route-pass/Router";
 import { Storage } from "../lib/storage/Storage";
-import { mainWindow } from "../main";
 import os from "os";
 
 Router.respond("settings::get", (_evt, key) => {
@@ -13,24 +12,4 @@ Router.respond("settings::write", (_evt, key, value) => {
 
 Router.respond("settings::getos", (_evt) => {
   return os.platform();
-});
-
-Router.respond("settings::maximize", (_evt) => {
-  if (mainWindow.isMaximized()) {
-    mainWindow.unmaximize();
-    return;
-  }
-  mainWindow.maximize();
-});
-
-Router.respond("settings::maximized", (_evt) => {
-  return mainWindow.isMaximized();
-});
-
-Router.respond("settings::minimize", (_evt) => {
-  mainWindow.minimize();
-});
-
-Router.respond("settings::close", (_evt) => {
-  mainWindow.close();
 });

--- a/src/main/router/window-router.ts
+++ b/src/main/router/window-router.ts
@@ -9,7 +9,7 @@ Router.respond("window::maximize", (_evt) => {
   mainWindow.maximize();
 });
 
-Router.respond("window::maximized", (_evt) => {
+Router.respond("window::isMaximized", (_evt) => {
   try {
     return mainWindow.isMaximized();
   } catch {

--- a/src/main/router/window-router.ts
+++ b/src/main/router/window-router.ts
@@ -1,0 +1,22 @@
+import { Router } from "../lib/route-pass/Router";
+import { mainWindow } from "../main";
+
+Router.respond("window::maximize", (_evt) => {
+  if (mainWindow.isMaximized()) {
+    mainWindow.unmaximize();
+    return;
+  }
+  mainWindow.maximize();
+});
+
+Router.respond("window::maximized", (_evt) => {
+  return mainWindow.isMaximized();
+});
+
+Router.respond("window::minimize", (_evt) => {
+  mainWindow.minimize();
+});
+
+Router.respond("window::close", (_evt) => {
+  mainWindow.close();
+});

--- a/src/main/router/window-router.ts
+++ b/src/main/router/window-router.ts
@@ -10,7 +10,11 @@ Router.respond("window::maximize", (_evt) => {
 });
 
 Router.respond("window::maximized", (_evt) => {
-  return mainWindow.isMaximized();
+  try {
+    return mainWindow.isMaximized();
+  } catch {
+    return false;
+  }
 });
 
 Router.respond("window::minimize", (_evt) => {

--- a/src/renderer/src/scenes/main-scene/MainScene.tsx
+++ b/src/renderer/src/scenes/main-scene/MainScene.tsx
@@ -11,7 +11,16 @@ import {
   toggleSongQueueModalOpen,
 } from "@renderer/components/song/song-queue/song-queue.utils";
 import { song } from "@renderer/components/song/song.utils";
-import { Component, For, JSXElement, Match, Show, Switch } from "solid-js";
+import {
+  Component,
+  createEffect,
+  createSignal,
+  For,
+  JSXElement,
+  Match,
+  Show,
+  Switch,
+} from "solid-js";
 
 const MainScene: Component = () => {
   return (
@@ -34,8 +43,21 @@ const MainScene: Component = () => {
 };
 
 const Nav: Component = () => {
+  const [os, setOs] = createSignal<NodeJS.Platform>();
+
+  createEffect(async () => {
+    const fetchOS = async () => {
+      return await window.api.request("settings::getos");
+    };
+    const os = await fetchOS();
+    setOs(os);
+  });
+
   return (
-    <nav class="nav">
+    <nav
+      class="nav"
+      style={os() === "darwin" ? { padding: "0px 20px 0px 95px" } : { padding: "0px 20px" }}
+    >
       <For each={Object.values(TABS)}>
         {({ label, ...rest }) => <NavItem {...rest}>{label}</NavItem>}
       </For>

--- a/src/renderer/src/scenes/main-scene/MainScene.tsx
+++ b/src/renderer/src/scenes/main-scene/MainScene.tsx
@@ -11,7 +11,7 @@ import {
   toggleSongQueueModalOpen,
 } from "@renderer/components/song/song-queue/song-queue.utils";
 import { song } from "@renderer/components/song/song.utils";
-import { Maximize, Minimize2, Minus, X } from "lucide-solid";
+import { Minimize2, Minus, Square, X } from "lucide-solid";
 import {
   Accessor,
   Component,
@@ -101,9 +101,12 @@ function WindowControls(props: { maximized: Accessor<boolean>; setMaximized: Set
         }}
         class="nav-window-control"
       >
-        {props.maximized() ? <Minimize2 size={20} /> : <Maximize size={20} />}
+        {props.maximized() ? <Minimize2 size={20} /> : <Square size={18} />}
       </button>
-      <button onclick={async () => window.api.request("window::close")} class="nav-window-control">
+      <button
+        onclick={async () => window.api.request("window::close")}
+        class="nav-window-control close"
+      >
         <X size={20} />
       </button>
     </div>

--- a/src/renderer/src/scenes/main-scene/MainScene.tsx
+++ b/src/renderer/src/scenes/main-scene/MainScene.tsx
@@ -54,12 +54,12 @@ const Nav: Component = () => {
       return await window.api.request("settings::getos");
     };
 
-    const fetchmaximized = async () => {
-      return await window.api.request("settings::maximized");
+    const fetchMaximized = async () => {
+      return await window.api.request("window::maximized");
     };
 
     setOs(await fetchOS());
-    setMaximized(await fetchmaximized());
+    setMaximized(await fetchMaximized());
   });
 
   return (
@@ -76,33 +76,30 @@ const Nav: Component = () => {
           <i class="ri-stack-fill nav__queue-icon" />
         </IconButton>
       </div>
-      {os() !== "darwin" && <NavWindowControls maximized={maximized} setMaximized={setMaximized} />}
+      {os() !== "darwin" && <WindowControls maximized={maximized} setMaximized={setMaximized} />}
     </nav>
   );
 };
 
-function NavWindowControls(props: { maximized: Accessor<boolean>; setMaximized: Setter<boolean> }) {
+function WindowControls(props: { maximized: Accessor<boolean>; setMaximized: Setter<boolean> }) {
   return (
     <div class="nav-window-controls">
       <button
-        onclick={async () => window.api.request("settings::minimize")}
+        onclick={async () => window.api.request("window::minimize")}
         class="nav-window-control"
       >
         <Minus size={20} />
       </button>
       <button
         onclick={async () => {
-          window.api.request("settings::maximize");
+          window.api.request("window::maximize");
           props.setMaximized(!props.maximized());
         }}
         class="nav-window-control"
       >
         {props.maximized() ? <Minimize2 size={20} /> : <Maximize size={20} />}
       </button>
-      <button
-        onclick={async () => window.api.request("settings::close")}
-        class="nav-window-control"
-      >
+      <button onclick={async () => window.api.request("window::close")} class="nav-window-control">
         <X size={20} />
       </button>
     </div>

--- a/src/renderer/src/scenes/main-scene/MainScene.tsx
+++ b/src/renderer/src/scenes/main-scene/MainScene.tsx
@@ -51,11 +51,11 @@ const Nav: Component = () => {
 
   createEffect(async () => {
     const fetchOS = async () => {
-      return await window.api.request("settings::getos");
+      return await window.api.request("os::platform");
     };
 
     const fetchMaximized = async () => {
-      return await window.api.request("window::maximized");
+      return await window.api.request("window::isMaximized");
     };
 
     setOs(await fetchOS());

--- a/src/renderer/src/scenes/main-scene/MainScene.tsx
+++ b/src/renderer/src/scenes/main-scene/MainScene.tsx
@@ -60,6 +60,10 @@ const Nav: Component = () => {
 
     setOs(await fetchOS());
     setMaximized(await fetchMaximized());
+
+    window.api.listen("window::maximizeChange", (maximized: boolean) => {
+      setMaximized(maximized);
+    });
   });
 
   return (

--- a/src/renderer/src/scenes/main-scene/styles.css
+++ b/src/renderer/src/scenes/main-scene/styles.css
@@ -63,6 +63,7 @@
     padding: 0px 20px;
     background: var(--contrast-background);
     gap: 4px;
+    -webkit-app-region: drag;
 
     .nav-item {
       display: flex;
@@ -70,6 +71,7 @@
       gap: 16px;
       padding: 4px 16px;
       border-radius: var(--rounded-sm);
+      -webkit-app-region: no-drag;
 
       &:is(:hover, :focus) {
         background: var(--hover-background);
@@ -110,6 +112,8 @@
       &[data-active="true"] {
         color: var(--text-900);
       }
+
+      -webkit-app-region: no-drag;
     }
   }
 }

--- a/src/renderer/src/scenes/main-scene/styles.css
+++ b/src/renderer/src/scenes/main-scene/styles.css
@@ -83,6 +83,10 @@
       background: var(--hover-background);
     }
 
+    .nav-window-control.close:hover {
+      background: red;
+    }
+
     .nav-item {
       display: flex;
       align-items: center;

--- a/src/renderer/src/scenes/main-scene/styles.css
+++ b/src/renderer/src/scenes/main-scene/styles.css
@@ -65,6 +65,24 @@
     gap: 4px;
     -webkit-app-region: drag;
 
+    .nav-window-controls {
+      height: 100%;
+      display: flex;
+      -webkit-app-region: no-drag;
+    }
+
+    .nav-window-control {
+      width: 45px;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .nav-window-control:hover {
+      background: var(--hover-background);
+    }
+
     .nav-item {
       display: flex;
       align-items: center;

--- a/src/renderer/src/scenes/main-scene/styles.css
+++ b/src/renderer/src/scenes/main-scene/styles.css
@@ -84,7 +84,7 @@
     }
 
     .nav-window-control.close:hover {
-      background: red;
+      background: hsl(0, 69%, 50%);
     }
 
     .nav-item {


### PR DESCRIPTION
Removes the default window titlebar and adds custom html buttons for non-macos platforms. Also adds lucide-solid
<img width="1431" alt="Screenshot 2024-10-11 at 3 13 22 PM" src="https://github.com/user-attachments/assets/034a88c3-92e0-4e9c-8ce5-00e7b8be48bc">
