### PR TITLE
fix: zoom controls, reverts #59

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,20 @@ async function createWindow() {
 
   trackBounds(window);
 
+  window.webContents.on("before-input-event", (event, input) => {
+    if (input.control && ["+", "=", "-", "0"].includes(input.key)) {
+      if (input.key === "+" || input.key === "=") {
+        zoom(window, 0.1);
+      } else if (input.key === "-") {
+        zoom(window, -0.1);
+      } else if (input.key === "0") {
+        zoom(window);
+      }
+
+      event.preventDefault();
+    }
+  });
+
   window.on("ready-to-show", async () => {
     window.show();
     await Router.dispatch(window, "changeScene", "main");
@@ -105,3 +119,8 @@ app.on("window-all-closed", () => {
     app.quit();
   }
 });
+
+function zoom(window: BrowserWindow, factor?: number) {
+  const currentZoom = window.webContents.getZoomFactor();
+  window.webContents.setZoomFactor(factor ? currentZoom + factor : 1);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,7 @@ async function createWindow() {
   trackBounds(window);
 
   window.webContents.on("before-input-event", (event, input) => {
-    if (input.control && ["+", "=", "-", "0"].includes(input.key)) {
+    if ((input.control || input.meta) && ["+", "=", "-", "0"].includes(input.key)) {
       if (input.key === "+" || input.key === "=") {
         zoom(window, 0.1);
       } else if (input.key === "-") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,8 @@ async function createWindow() {
   trackBounds(window);
 
   window.webContents.on("before-input-event", (event, input) => {
-    if ((input.control || input.meta) && ["+", "=", "-", "0"].includes(input.key)) {
+    const modKeyHeld = process.platform === "darwin" ? input.meta : input.control;
+    if (modKeyHeld && ["+", "=", "-", "0"].includes(input.key)) {
       if (input.key === "+" || input.key === "=") {
         zoom(window, 0.1);
       } else if (input.key === "-") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import { Router } from "./lib/route-pass/Router";
 import trackBounds, { getBounds, wasMaximized } from "./lib/window/resizer";
 import { main } from "./main";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
-import { app, BrowserWindow, dialog, globalShortcut } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import { join } from "path";
 
 async function createWindow() {
@@ -89,12 +89,6 @@ app.whenReady().then(async () => {
     optimizer.watchWindowShortcuts(window);
   });
 
-  // Zoom shortcuts. Adding all three because there were mixed reports
-  // of which one works or not on different platforms.
-  globalShortcut.register("CommandOrControl+=", () => zoom(0.1));
-  globalShortcut.register("CommandOrControl+-", () => zoom(-0.1));
-  globalShortcut.register("CommandOrControl+0", () => zoom());
-
   await createWindow();
 
   app.on("activate", async () => {
@@ -111,11 +105,3 @@ app.on("window-all-closed", () => {
     app.quit();
   }
 });
-
-function zoom(factor?: number) {
-  const focusedWindow = BrowserWindow.getFocusedWindow();
-  if (focusedWindow) {
-    const currentZoom = focusedWindow.webContents.getZoomFactor();
-    focusedWindow.webContents.setZoomFactor(factor ? currentZoom + factor : 1);
-  }
-}


### PR DESCRIPTION
I'm pretty sure that this is bad and that we shouldn't do this. I believe that if you register a global shortcut on Windows no other app can claim it while that app is active. It also doesn't even work for me on Linux, but that might be because of Wayland. The zoom issue should still be fixed, just not this way.