### PR TITLE
fix: zoom (again)

### DIFF
--- a/src/main/lib/window/menu.ts
+++ b/src/main/lib/window/menu.ts
@@ -1,0 +1,31 @@
+import { Menu, type MenuItemConstructorOptions } from "electron";
+
+export default function createMenu() {
+  const menuTemplate: MenuItemConstructorOptions[] = [
+    { role: "fileMenu" },
+    { role: "editMenu" },
+    {
+      role: "viewMenu",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomIn", accelerator: "CommandOrControl+=", visible: false },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    { role: "windowMenu" },
+    { role: "help" },
+  ];
+
+  if (process.platform === "darwin") {
+    menuTemplate.unshift({ role: "appMenu" });
+  }
+
+  return Menu.buildFromTemplate(menuTemplate);
+}


### PR DESCRIPTION
I randomly stumbled upon this open issue in the electron-toolkit repo and it's exactly about the zoom issue we're having lol https://github.com/alex8088/electron-toolkit/issues/17. Apparently electron-toolkit just disables it by default (but not properly which is why it was so inconsistent between platforms for us).

That should hopefully fix `Ctrl+` and `Ctrl-`. However since `Ctrl=` is also nice to have I've recreated the default Menu but with an additional invisible entry for the `CommandOrControl+=` accelerator (this is basically the way to do it until https://github.com/electron/electron/issues/5256 has been implemented).