### PR TITLE
Change wording so the user doesn't input their actual osu Songs folder and enters the osu! directory instead.

### DIFF
--- a/src/renderer/src/scenes/dir-select-scene/DirSelectScene.tsx
+++ b/src/renderer/src/scenes/dir-select-scene/DirSelectScene.tsx
@@ -49,7 +49,7 @@ export default function DirSelectScene() {
 
         <div class="flex flex-col gap-4">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-bold text-text">Your osu! Songs folder</label>
+            <label class="text-sm font-bold text-text">Your osu! folder</label>
             <div
               onClick={selectDir}
               class="flex items-baseline justify-between rounded-xl border border-white/5 bg-regular-material p-1 pl-4"


### PR DESCRIPTION
The program tries to read the database file from the given folder, which is not the osu Songs folder. I tried inputting my osu Songs folder (which resides in `C:\OsuSongs\` for me) and was annoyed when it didn't work.