### PR TITLE
ci: add cache, add prettier, parallelize jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,4 +15,3 @@ runs:
 
     - shell: bash
       run: npm ci
-

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,6 @@ description: "Setup and install dependencies"
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: "Setup"
+description: "Setup and install dependencies"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+        cache: "npm"
+
+    - shell: bash
+      run: npm ci
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: Static Analysis
+name: CI
+
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup
         uses: ./.github/actions/setup
 
@@ -25,6 +28,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup
         uses: ./.github/actions/setup
 
@@ -35,6 +41,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup
         uses: ./.github/actions/setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,28 @@ on:
     branches:
       - master
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
-  Typing-and-Linting:
+  typecheck:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - name: Install dependencies
-        run: npm install
+      - name: Setup
+        uses: ../actions/setup
+
       - name: Run TypeScript compiler
         run: npm run typecheck
-      - name: Run Eslint check
-        run: npm run lint:check
+
+  lint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        uses: ../actions/setup
+
+      - name: Run Eslint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup
-        uses: ../actions/setup
+        uses: ./.github/actions/setup
 
       - name: Run TypeScript compiler
         run: npm run typecheck
@@ -26,17 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup
-        uses: ../actions/setup
+        uses: ./.github/actions/setup
 
       - name: Run Eslint
-        run: npm run lint
+        run: npm run lint:check
 
   format:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Setup
-        uses: ../actions/setup
+        uses: ./.github/actions/setup
 
       - name: Run Prettier
         run: npm run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,13 @@ jobs:
 
       - name: Run Eslint
         run: npm run lint
+
+  format:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        uses: ../actions/setup
+
+      - name: Run Prettier
+        run: npm run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 jobs:
   Typing-and-Linting:
     runs-on: ubuntu-latest

--- a/build/notarize.js
+++ b/build/notarize.js
@@ -2,7 +2,7 @@ import { notarize } from "@electron/notarize";
 
 export default async (context) => {
   if (process.platform !== "darwin") return;
-  
+
   console.log("aftersign hook triggered, start to notarize app.");
 
   if (!process.env.CI) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,17 +12,16 @@ async function createWindow() {
   const [width, height] = getBounds();
 
   function getIcon(): string {
-    if (process.platform === 'win32') {
-      return join(__dirname, '../../build/icon.ico');
+    if (process.platform === "win32") {
+      return join(__dirname, "../../build/icon.ico");
     }
-  
-    if (process.platform === 'darwin') {
-      return join(__dirname, '../../build/icon.icns');
-    }
-  
-    return join(__dirname, '../../build/icon.png');
-  }
 
+    if (process.platform === "darwin") {
+      return join(__dirname, "../../build/icon.icns");
+    }
+
+    return join(__dirname, "../../build/icon.png");
+  }
 
   const window = new BrowserWindow({
     title: "osu!radio",


### PR DESCRIPTION
- Split steps into multiple jobs so that they're run and displayed separately (and concurrently)
- Create reusable setup action
- Have CI run for all PRs, not just against master
- Enable caching (doesn't cache node_modules, it's just a global package cache that's used when the lockfile hasn't changed)
- Add Prettier formatting check