### PR TITLE
Fix code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/src/renderer/src/components/song/song-queue/SongQueue.tsx
+++ b/src/renderer/src/components/song/song-queue/SongQueue.tsx
@@ -52,7 +52,7 @@ const SongQueue: Component = () => {
       selected.classList.remove("selected");
     }
 
-    const path = song.path.replaceAll('"', '\\"').replaceAll("\\", "\\\\");
+    const path = song.path.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
     const element = view.querySelector<HTMLElement>(`.song-item[data-path="${path}"]`);
     element?.classList.add("selected");
 


### PR DESCRIPTION
Fixes [https://github.com/Team-BTMC/osu-radio/security/code-scanning/1](https://github.com/Team-BTMC/osu-radio/security/code-scanning/1)

To fix the double escaping issue, we need to ensure that backslashes are escaped before any other characters. This way, any existing backslashes are correctly handled before other replacements are made. We will modify the `changeSongHighlight` function to first escape backslashes and then escape double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
