### PR TITLE
Fix osu!stable DB Parsing

### DIFF
--- a/src/main/lib/osu-file-parser/OsuParser.ts
+++ b/src/main/lib/osu-file-parser/OsuParser.ts
@@ -236,21 +236,24 @@ export class OsuParser {
         db.readFloat(); // OD
         db.readDouble(); // slider multiplier
 
+        // star ratings were changed to be stored as floats instead of doubles in 20250108
+        const sr_skip_value = db_version >= 20250108 ? 1 + 4 + 1 + 4 : 1 + 4 + 1 + 8;
+
         // std
         let nb_star_ratings = db.readInt();
-        db.pos += nb_star_ratings * (1 + 4 + 1 + 8); // skipping star ratings
+        db.pos += nb_star_ratings * sr_skip_value; // skipping star ratings
 
         // taiko
         nb_star_ratings = db.readInt();
-        db.pos += nb_star_ratings * (1 + 4 + 1 + 8); // skipping star ratings
+        db.pos += nb_star_ratings * sr_skip_value; // skipping star ratings
 
         // ctb
         nb_star_ratings = db.readInt();
-        db.pos += nb_star_ratings * (1 + 4 + 1 + 8); // skipping star ratings
+        db.pos += nb_star_ratings * sr_skip_value; // skipping star ratings
 
         // mania
         nb_star_ratings = db.readInt();
-        db.pos += nb_star_ratings * (1 + 4 + 1 + 8); // skipping star ratings
+        db.pos += nb_star_ratings * sr_skip_value; // skipping star ratings
 
         db.readInt(); // drain time
         song.duration = db.readInt() / 1000.0;


### PR DESCRIPTION
In osu!stable version [20250108](https://osu.ppy.sh/home/changelog/stable40/20250108.3), stable changed the way star rating is stored from doubles to floats, so this adds a check for the db version and applies the correct skip value accordingly.

Tested and can confirm it parses correctly for versions before and after the change