### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build/Release osu!radio
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types: [published, released, prereleased]
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          args: "-c.snap.publish=github"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: osu-radio-setup${{ matrix.os == 'windows-latest' && '.exe' || matrix.os == 'macos-latest' && '.dmg' || '.AppImage' }}
+          path: |
+            ${{ matrix.os == 'windows-latest' && 'dist/*.exe' || matrix.os == 'macos-latest' && 'dist/*.dmg' || 'dist/*.AppImage' }}
+          if-no-files-found: error
+          compression-level: 0

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 out
 dist
 package-lock.json
+.github

--- a/package.json
+++ b/package.json
@@ -75,5 +75,15 @@
     "vite-plugin-lucide-preprocess": "^1.1.1",
     "vite-plugin-solid": "^2.7.0"
   },
-  "packageManager": "^bun@1.1.33"
+  "build": {
+    "appId": "btmc.osu-radio",
+    "mac": {
+      "category": "public.app-category.music"
+    },
+    "snap": {
+      "publish": [
+        "github"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Note: Linux builds are intentionally disabled for now because electron-builder is terrible and seemingly has [no proper way to disable snap publishing](https://github.com/electron-userland/electron-builder/issues/4982), even [what their docs say](https://www.electron.build/publish#:~:text=You%20can%20also%20configure%20publishing%20using%20CLI%20arguments%2C%20for%20example%2C%20to%20force%20publishing%20snap%20not%20to%20Snap%20Store%2C%20but%20to%20GitHub%3A%20%2Dc.snap.publish%3Dgithub) doesn't work. If anyone can help figure that out I would greatly appreciate it.

Also removed the `packageManager` field from the package.json because it was conflicting with the electron-builder workflow using yarn to run scripts